### PR TITLE
Remove About and Resume links from nav bar and About Me title

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,18 +8,15 @@
         Machine Learning, Statistics, Computer Science
       </span>
       <p class="mb-0"><small class="text-muted">aka 'tnb'</small></p>
-      <ul class="list-inline">
-        <li class="list-inline-item">
-          <a href="{{ "/" | prepend: site.baseurl | prepend: site.url }}">About</a>
-        </li>
-      {% for content in site.pages %}
-        {% if content.title %}
-          <li class="list-inline-item">
-            <a href="{{ content.url | prepend: site.baseurl | prepend: site.url }}">{{ content.title }}</a>
-          </li>
-        {% endif %}
-      {% endfor %}
-      </ul>
+        <ul class="list-inline">
+        {% for content in site.pages %}
+          {% if content.title and content.title != "Resume" %}
+            <li class="list-inline-item">
+              <a href="{{ content.url | prepend: site.baseurl | prepend: site.url }}">{{ content.title }}</a>
+            </li>
+          {% endif %}
+        {% endfor %}
+        </ul>
   </div>
   <div class="col-auto mt-2">
     <img src="/img/me.png" width="150" height="150" class="rounded-circle" alt="Thomas">

--- a/index.html
+++ b/index.html
@@ -5,13 +5,6 @@ permalink: /
 
 <div class="row justify-content-center mt-5">
   <div class="col-auto">
-    <h1>
-      About Me
-    </h1>
-  </div>
-</div>
-<div class="row justify-content-center mt-5">
-  <div class="col-auto">
     <p>
       I'm an AI scientist currently doing frontier research at OpenAI. I sometimes go by 'tnb'
     </p>


### PR DESCRIPTION
## Summary
- remove static About link from header
- filter Resume page from navigation menu
- remove About Me heading from index page

## Testing
- `gem install jekyll -N` *(fails: 403 Forbidden)*
- `jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ece4a38c8332b5e08f7a2d39fafc